### PR TITLE
Support ideograms w/ brushes, tasks, and more `encodings` like annotation, arc, and matrix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,45 @@
+{
+    "parser": "babel-eslint",
+    "env": {
+        "browser": true,
+        "node": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended"
+    ],
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 6,
+        "sourceType": "module"
+    },
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
+    },
+    "plugins": [
+        "react"
+    ],
+    "rules": {
+        "indent": [
+            "error",
+            "tab"
+        ],
+        "react/prop-types": 0,
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "double"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn format && git add ."
+      "pre-commit": ""
     }
   }
 }

--- a/src/recommendation-panel/convert.js
+++ b/src/recommendation-panel/convert.js
@@ -4,7 +4,7 @@ import { getIdeogram, getOverview } from "./ideogram";
 // import { getIdeogram } from "./ideogram";
 
 // A flag variable to print log messages while debugging
-export const IS_DEBUG = true;
+export const IS_DEBUG = false;
 
 /**
  * Convert a Genorec recommendation spec into a list of Gosling.js specs.

--- a/src/recommendation-panel/encoding.js
+++ b/src/recommendation-panel/encoding.js
@@ -1,4 +1,5 @@
 import { getSampleColor } from "./color";
+import { IS_DEBUG } from "./convert";
 
 export const EXAMPLE_DATASETS = {
 	multivec: "https://resgen.io/api/v1/tileset_info/?d=UvVPeLHuRDiYA3qwFlm7xQ",
@@ -47,7 +48,7 @@ export function encodingToTrack(encoding, config) {
 	const { 
 		title, 
 		width, 
-		index
+		index = 0
 	} = config;
 
 	const trackBase = {
@@ -73,6 +74,17 @@ export function encodingToTrack(encoding, config) {
 			size: { value: 1 },
 			opacity: { value: 0.8 }
 		};
+	case "dotPlot":
+		return {
+			...JSON.parse(JSON.stringify(trackBase)),
+			...JSON.parse(JSON.stringify(getMultivecData(index))),
+			mark: "point", 
+			x: { field: "position", type: "genomic" },
+			y: { field: "peak", type: "quantitative", axis: "right", grid: true },
+			color: { value: getSampleColor(index) },
+			size: { value: 4 },
+			opacity: { value: 0.8 }
+		};
 	case "barChart":
 	case "intervalBarChart":
 		return {
@@ -86,9 +98,156 @@ export function encodingToTrack(encoding, config) {
 			strokeWidth: { value: 0.5 },
 			opacity: { value: 0.8 }
 		};
+	case "barChartCN":
+	case "intervalBarChartCN":
+		return {
+			...JSON.parse(JSON.stringify(trackBase)),
+			"data": {
+				"url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation",
+				"type": "beddb",
+				"genomicFields": [
+					{ "index": 1, "name": "start" },
+					{ "index": 2, "name": "end" }
+				],
+				"valueFields": [
+					{ "index": 5, "name": "strand", "type": "nominal" },
+					{ "index": 3, "name": "name", "type": "nominal" },
+					{ "index": 4, "name": "4", "type": "nominal" },
+					{ "index": 6, "name": "6", "type": "nominal" },
+					{ "index": 7, "name": "7", "type": "nominal" },
+					{ "index": 8, "name": "8", "type": "nominal" },
+					{ "index": 9, "name": "9", "type": "nominal" },
+					{ "index": 10, "name": "10", "type": "nominal" },
+					{ "index": 11, "name": "11", "type": "nominal" },
+				],
+				"exonIntervalFields": [
+					{ "index": 12, "name": "start" },
+					{ "index": 13, "name": "end" }
+				]
+			},
+			"dataTransform": [
+				{ type: "filter", "field": "type", "oneOf": ["gene"] },
+				{ type: "filter", "field": "strand", "oneOf": ["+"] }
+			],
+			mark: "rect",
+			x: { "field": "start", "type": "genomic" },
+			xe: { "field": "end", "type": "genomic" },
+			stroke: { "field": "8", "type": "nominal" },
+			strokeWidth: { value: 4 },
+			color: { "field": "8", "type": "nominal", legend: true, domain: ["protein-coding", "ncRNA", "snRNA"] },
+		};
+		// https://github.com/hms-dbmi/cistrome-explorer/blob/b12238aeadbaf4a41f5445c32dbe3d6518d6fd1d/src/viewconfigs/horizontal-multivec-1.js#L136
+		// return {
+		// 	...JSON.parse(JSON.stringify(trackBase)),
+		// 	"data": {
+		// 		"url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=gwas-beddb",
+		// 		"type": "beddb",
+		// 		"genomicFields": [
+		// 			{"index": 1, "name": "start"},
+		// 			{"index": 2, "name": "end"}
+		// 		],
+		// 		"valueFields": [
+		// 			{"index": 3, "name": "pubmedid", "type": "nominal"},
+		// 			{"index": 4, "name": "date", "type": "nominal"},
+		// 			{"index": 5, "name": "link", "type": "nominal"},
+		// 			{"index": 6, "name": "pvalue", "type": "quantitative"},
+		// 			{"index": 8, "name": "disease", "type": "nominal"},
+		// 			{"index": 9, "name": "pvalue_log", "type": "quantitative"},
+		// 			{"index": 10, "name": "pvalue_txt", "type": "nominal"}
+		// 		]
+		// 	},
+		// 	mark: "rect",
+		// 	x: { field: "start", type: "genomic" },
+		// 	xe: {field: "end", "type": "genomic" },
+		// 	color: { field: "disease", type: "nominal", legend: true },
+		// 	stroke: { field: "disease", type: "nominal" },
+		// 	strokeWidth: { value: 5 }
+		// };
 	case "heatmap":
 	case "intervalHeatmap":
+		return {
+			...JSON.parse(JSON.stringify(trackBase)),
+			...JSON.parse(JSON.stringify(getMultivecData(index))),
+			mark: "rect",
+			x: { field: "start", type: "genomic" },
+			xe: { field: "end", type: "genomic" },
+			color: { field: "peak", type: "quantitative", range: "grey", legend: true },
+			opacity: { value: 0.8 }
+		};
+	case "link":
+		return {
+			...JSON.parse(JSON.stringify(trackBase)),
+			data: {
+				url: "https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt",
+				type: "csv",
+				chromosomeField: "c2",
+				genomicFields: ["s1", "e1", "s2", "e2"]
+			},
+			mark: "withinLink",
+			x: { field: "s1", type: "genomic" },
+			xe: { field: "e1", type: "genomic" },
+			x1: { field: "s2", type: "genomic" },
+			x1e: { field: "e2", type: "genomic" },
+			color: { value: "none" },
+			stroke: { value: "gray" },
+			opacity: { value: 0.3 }
+		};
+	case "matrix":
+		// custom encoding key for dense-orthogonal interaction
+		return {
+			...JSON.parse(JSON.stringify(trackBase)),
+			data: {
+				"url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=hffc6-microc-hg38",
+				"type": "matrix"
+			},
+			mark: "rect",
+			x: { "field": "position1", "type": "genomic", "axis": "top" },
+			y: { "field": "position2", "type": "genomic", "axis": "right" },
+			color: { "field": "value", "type": "quantitative", "range": "warm" },
+			width,
+			height: width
+		};
+	case "annotation":
+		return {
+			...JSON.parse(JSON.stringify(trackBase)),
+			"data": {
+				"url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation",
+				"type": "beddb",
+				"genomicFields": [
+					{ "index": 1, "name": "start" },
+					{ "index": 2, "name": "end" }
+				],
+				"valueFields": [
+					{ "index": 5, "name": "strand", "type": "nominal" },
+					{ "index": 3, "name": "name", "type": "nominal" },
+					{ "index": 4, "name": "4", "type": "nominal" },
+					{ "index": 6, "name": "6", "type": "nominal" },
+					{ "index": 7, "name": "7", "type": "nominal" },
+					{ "index": 8, "name": "8", "type": "nominal" },
+					{ "index": 9, "name": "9", "type": "nominal" },
+					{ "index": 10, "name": "10", "type": "nominal" },
+					{ "index": 11, "name": "11", "type": "nominal" },
+				],
+				"exonIntervalFields": [
+					{ "index": 12, "name": "start" },
+					{ "index": 13, "name": "end" }
+				]
+			},
+			"dataTransform": [
+				{ type: "filter", "field": "type", "oneOf": ["gene"] },
+				{ type: "filter", "field": "strand", "oneOf": ["+"] }
+			],
+			mark: "text",
+			text: { field: "name", "type": "nominal" }, // lets always use the name
+			// text: { field: ["name", "strand", "4", "6", "7", "8", "9", "10", "11"][i % 4], "type": "nominal" },
+			x: { "field": "start", "type": "genomic" },
+			xe: { "field": "end", "type": "genomic" },
+			displacement: {"type": "pile", "padding": 30},
+			color: { value: "gray" },
+			opacity: { "value": 0.8 }
+		};
 	default:
+		if(IS_DEBUG) console.log(`%c Unsupported Encoding: ${encoding}`, "color: orange; font-size: 24px");
 		return {
 			...JSON.parse(JSON.stringify(trackBase)),
 			...JSON.parse(JSON.stringify(getMultivecData(index))),

--- a/src/recommendation-panel/gene-annotation.js
+++ b/src/recommendation-panel/gene-annotation.js
@@ -1,5 +1,6 @@
 export function getGeneAnnotation(width, height) {
 	return  {
+		title: "Genes",
 		"template": "gene",
 		"data": {
 			"url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation",

--- a/src/recommendation-panel/ideogram.js
+++ b/src/recommendation-panel/ideogram.js
@@ -1,4 +1,97 @@
-export const getIdeogram = (A, B, width, block = true) => {
+export function getOverview(width, height) {
+	return {
+		static: true,
+		alignment: "overlay",
+		title: "Whole Genome",
+		"data": {
+			"url": "https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv",
+			"type": "csv",
+			"chromosomeField": "Chromosome",
+			"genomicFields": ["chromStart", "chromEnd"]
+		},
+		"tracks": [
+			{
+				"mark": "rect",
+				"color": {
+					"field": "Chromosome",
+					"type": "nominal",
+					"domain": [
+						"chr1",
+						"chr2",
+						"chr3",
+						"chr4",
+						"chr5",
+						"chr6",
+						"chr7",
+						"chr8",
+						"chr9",
+						"chr10",
+						"chr11",
+						"chr12",
+						"chr13",
+						"chr14",
+						"chr15",
+						"chr16",
+						"chr17",
+						"chr18",
+						"chr19",
+						"chr20",
+						"chr21",
+						"chr22",
+						"chrX",
+						"chrY"
+					],
+					"range": ["#F6F6F6", "black"]
+				},
+				"x": {"field": "chromStart", "type": "genomic", "aggregate": "min"},
+				"xe": {"field": "chromEnd", "aggregate": "max", "type": "genomic"},
+			},
+			{
+				mark: "brush",
+				x: { linkingId: "A" },
+				// color: { value: 'blue' },
+				stroke: { value: "black" },
+				strokeWidth: { value: 2 }
+			},
+			{
+				mark: "brush",
+				x: { linkingId: "B" },
+				// color: { value: 'red' },
+				stroke: { value: "black" },
+				strokeWidth: { value: 2 }
+			}
+		],
+		"stroke": {"value": "gray"},
+		"strokeWidth": {"value": 0.5},
+		"style": {"outline": "black"},
+		width,
+		height
+	};
+}
+export function getIdeogram(width, height) {
+	return {
+		title: "Ideogram",
+		"template": "ideogram",
+		"data": {
+			"url": "https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv",
+			"type": "csv",
+			"chromosomeField": "Chromosome",
+			"genomicFields": ["chromStart", "chromEnd"]
+		},
+		"encoding": {
+			"startPosition": {"field": "chromStart"},
+			"endPosition": {"field": "chromEnd"},
+			"stainBackgroundColor": {"field": "Stain"},
+			"stainLabelColor": {"field": "Stain"},
+			"name": {"field": "Name"},
+			"stainStroke": {"value": "black"}
+		},
+		width,
+		height
+	};
+}
+
+export const _getIdeogram = (A, B, width, block = true) => {
 	if(block) {
 		return {
 			static: true,


### PR DESCRIPTION
# Update
This PR adds the following features in the conversion step:
- Show overviews
- Show ideograms in each view with interactive brushes
- Handle tasks (e.g., show one or two chromosomes in single or multiple ROI tasks)
- Support more `encoding`s like `annotation`, arcs, matrix, ...

## Possible Improvements
### Conversion
- [ ] Need better handling for matrix (Need to understand better about the genorec output).
- [x] `showIdeogram` should be considered in the conversion once it is supported in the `Genorec-Client`.
- [x] Distinction of Point and Segment is not considered, but wonder if it is realistic to distinguish them. Point- and segment-based bigwig files, for example, would look the same in the whole genome scale. They would be differentiable only when zoomed in very far (e.g., ~k bps). And preparing them would require much time. I think we can revisit this issue after addressing more important issues.
- [ ] Need to infer the track name for the connectivity info (i.e., arc and matrix) since it is not explicitly specified in the same level where connectivity information is specified.
- [ ] `"overlay"` is not handled, and I did not find a case that recommends the `"overlay"` yet.
- [x] For `"segregated"`, I showed only the first five chromosomes for the performance and limited screen space. We may need to revisit this if this is a right decision.

### Data Preparation
- [ ] Quantitative sparse data
- [ ] Categorical sparse data
- [ ] Quantitative and Categorical connectivity data?
- [ ] Probably prepare files for VCF and SEG (at least one for each)?
- [ ] Probably use GWAS data for vcf

### Genorec-Client
- [x] Remove pre-commit before merging for the convenience of Adi
- [x] Need to show only several recommendations at once for the performance issue (especially, matrix is slow).
- [ ] Add a button to export a PNG/PDF file of a recommended option?

### Genorec-Engine
- [ ] Put `layout` in the view level? (tracks in a single view have the same layout, and having `layout` in the track level means it can vary by tracks.)
- [ ] Wonder if this is a mistake in the engine, but I think the `interconnection` should appear only once per view.
- [ ] Inconsistent encoding/layout across views or tracks needs to be addressed (e.g., one track uses bars and the other uses lines).

### Gosling.js
- [x] ~~Allow "horizontal" orientation of color legend?~~ Allow a compact quantitative color legend
- [x] In circular layouts, show tracks titles directly on each track. Currently, multiple track titles are overlapped on the left-top corner.
- [ ] How to show multiple color legends in circular layouts?
- [ ] `adjacent` semi-circle views are not currently supported (https://github.com/gosling-lang/gosling.js/issues/203)

### Screenshots
![Screen Shot 2021-08-11 at 2 57 49 PM](https://user-images.githubusercontent.com/9922882/129087574-8b62f97d-3d9b-4df0-b733-51c9b3faffb5.png)
![Screen Shot 2021-08-11 at 3 47 51 PM](https://user-images.githubusercontent.com/9922882/129093581-0e362621-600e-47bd-bb21-e36b5ceac76c.png)
![Screen Shot 2021-08-11 at 3 47 36 PM](https://user-images.githubusercontent.com/9922882/129093582-9202489d-af74-4ced-9cab-49d7f8864f81.png)
![Screen Shot 2021-08-11 at 4 11 25 PM](https://user-images.githubusercontent.com/9922882/129096570-ee582dc4-dd7f-4101-8896-01a79f3328d9.png)

